### PR TITLE
Update Jenkinsfile to address some of the npm-groovy-lint issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+/* groovylint-disable CompileStatic, NestedBlockDepth */
+
 pipeline {
     agent any
     environment {
@@ -33,7 +35,7 @@ pipeline {
                     branches: [[name: '*/main']],
                     extensions: [],
                     userRemoteConfigs: [[url: 'https://github.com/fireant-bot/fireant.git']]
-                	]
+                    ]
                 )
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,9 +26,15 @@ pipeline {
         cron('0 0 * * *')
     }
     stages {
-        stage('Checkout'){
+        stage('Checkout') {
             steps {
-                checkout([$class: 'GitSCM', branches: [[name: '*/main']], extensions: [], userRemoteConfigs: [[url: 'https://github.com/fireant-bot/fireant.git']]])
+                checkout(
+                    [$class: 'GitSCM',
+                    branches: [[name: '*/main']],
+                    extensions: [],
+                    userRemoteConfigs: [[url: 'https://github.com/fireant-bot/fireant.git']]
+                	]
+                )
             }
         }
         stage('Build') {
@@ -63,5 +69,3 @@ pipeline {
         }*/
     }
 }
-
-


### PR DESCRIPTION
When I run [npm-groovy-lint](https://github.com/nvuillam/npm-groovy-lint) I still get the following issues
```
/Users/lmcgibbn/Downloads/fireant/Jenkinsfile
  0     info     The tab character is not allowed in source files  NoTabCharacter
  18    info     Class should be marked with one of @GrailsCompileStatic, @CompileStatic or @CompileDynamic  CompileStatic
  50    warning  The nested block depth is 6  NestedBlockDepth
  70    info     File Jenkinsfile does not end with a newline  FileEndsWithoutNewline


npm-groovy-lint results in 1 linted files:
┌─────────┬───────────┬─────────────┐
│ (index) │ Severity  │ Total found │
├─────────┼───────────┼─────────────┤
│    0    │  'Error'  │      0      │
│    1    │ 'Warning' │      1      │
│    2    │  'Info'   │      3      │
└─────────┴───────────┴─────────────┘
```
@mjemnawaz I would eventually like this tool to run as part of the CI process for every incoming PR to this repository. Failing that, I would like to you take care of looking into these issues. Thank you