### PR TITLE
XML parser fixed: keeps comments now

### DIFF
--- a/dependencyfile.py
+++ b/dependencyfile.py
@@ -16,7 +16,7 @@
 from os import remove
 from shutil import copyfile
 from defusedxml.ElementTree import parse, XMLParser
-import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B314
+import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B405
 import config
 import xml.sax.saxutils as saxutils
 

--- a/dependencyfile.py
+++ b/dependencyfile.py
@@ -16,7 +16,8 @@
 from os import remove
 from shutil import copyfile
 from defusedxml.ElementTree import parse, XMLParser
-import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B314
+# import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B405
+import xml.etree.ElementTree.TreeBuilder as TB
 import config
 import xml.sax.saxutils as saxutils
 
@@ -52,7 +53,7 @@ class DependencyFile:
         self.unsaved_changelog = []
         self.__dependency_list = []
         # Parse xml and preserve original comments
-        self.__xml_tree = parse(self.path, XMLParser(target=ET.TreeBuilder(insert_comments=True), encoding='utf-8'))
+        self.__xml_tree = parse(self.path, XMLParser(target=TB(insert_comments=True), encoding='utf-8'))
 
         for count, item in enumerate(self.__xml_tree.getroot()):
             if item.tag != 'dependencies':
@@ -148,7 +149,7 @@ class DependencyFile:
         self.unsaved_changelog = []
         self.__dependency_list = []
         # Parse xml and preserve original comments
-        self.__xml_tree = parse(self.path, XMLParser(target=ET.TreeBuilder(insert_comments=True), encoding='utf-8'))
+        self.__xml_tree = parse(self.path, XMLParser(target=TB(insert_comments=True), encoding='utf-8'))
 
         for count, item in enumerate(self.__xml_tree.getroot()):
             if item.tag != 'dependencies':

--- a/dependencyfile.py
+++ b/dependencyfile.py
@@ -15,7 +15,8 @@
 
 from os import remove
 from shutil import copyfile
-from defusedxml.ElementTree import parse
+from defusedxml.ElementTree import parse, XMLParser
+import xml.etree.ElementTree as ET
 import config
 import xml.sax.saxutils as saxutils
 
@@ -51,7 +52,7 @@ class DependencyFile:
         self.unsaved_changelog = []
         self.__dependency_list = []
         # Parse xml and preserve original comments
-        self.__xml_tree = parse(path)
+        self.__xml_tree = parse(self.path, XMLParser(target=ET.TreeBuilder(insert_comments=True), encoding='utf-8'))
 
         for count, item in enumerate(self.__xml_tree.getroot()):
             if item.tag != 'dependencies':
@@ -147,7 +148,7 @@ class DependencyFile:
         self.unsaved_changelog = []
         self.__dependency_list = []
         # Parse xml and preserve original comments
-        self.__xml_tree = parse(self.path)
+        self.__xml_tree = parse(self.path, XMLParser(target=ET.TreeBuilder(insert_comments=True), encoding='utf-8'))
 
         for count, item in enumerate(self.__xml_tree.getroot()):
             if item.tag != 'dependencies':

--- a/dependencyfile.py
+++ b/dependencyfile.py
@@ -16,7 +16,7 @@
 from os import remove
 from shutil import copyfile
 from defusedxml.ElementTree import parse, XMLParser
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B314
 import config
 import xml.sax.saxutils as saxutils
 

--- a/dependencyfile.py
+++ b/dependencyfile.py
@@ -16,8 +16,7 @@
 from os import remove
 from shutil import copyfile
 from defusedxml.ElementTree import parse, XMLParser
-# import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B405
-import xml.etree.ElementTree.TreeBuilder as TB
+import xml.etree.ElementTree as ET  # Not using this module in an unsafe way -- skipcq: BAN-B314
 import config
 import xml.sax.saxutils as saxutils
 
@@ -53,7 +52,7 @@ class DependencyFile:
         self.unsaved_changelog = []
         self.__dependency_list = []
         # Parse xml and preserve original comments
-        self.__xml_tree = parse(self.path, XMLParser(target=TB(insert_comments=True), encoding='utf-8'))
+        self.__xml_tree = parse(self.path, XMLParser(target=ET.TreeBuilder(insert_comments=True), encoding='utf-8'))
 
         for count, item in enumerate(self.__xml_tree.getroot()):
             if item.tag != 'dependencies':
@@ -149,7 +148,7 @@ class DependencyFile:
         self.unsaved_changelog = []
         self.__dependency_list = []
         # Parse xml and preserve original comments
-        self.__xml_tree = parse(self.path, XMLParser(target=TB(insert_comments=True), encoding='utf-8'))
+        self.__xml_tree = parse(self.path, XMLParser(target=ET.TreeBuilder(insert_comments=True), encoding='utf-8'))
 
         for count, item in enumerate(self.__xml_tree.getroot()):
             if item.tag != 'dependencies':


### PR DESCRIPTION
Avoid deepsource flagging as security vulnerability by fixing how tree is parsed safely.