### PR TITLE
Issue 26 Webhook configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,9 @@ pipeline {
     }
     triggers {
         cron('0 0 * * *')
+        GenericTrigger(
+            tokenCredentialId: 'FIREANT_WEBHOOK'
+        )
     }
     stages {
         stage('Checkout') {


### PR DESCRIPTION
Might have to check "Generic Webhook Trigger" under "Build Triggers" in the Jenkins job configurations for the configurations to work.